### PR TITLE
Show Selected Tab Images

### DIFF
--- a/src/FSVerticalTabBar.m
+++ b/src/FSVerticalTabBar.m
@@ -170,7 +170,23 @@
     
     UITabBarItem *item = [self.items objectAtIndex:indexPath.row];
     cell.textLabel.text = item.title;
-    cell.iconImage = item.image;
+    
+    //add non-selected image
+    if(item.image != nil)
+    {
+        cell.iconImage = item.image;
+    } else if(item.image == nil && item.finishedUnselectedImage != nil)
+    {
+        //sometimes users will define the tabBar image through [tabBar setFinishedSelectedImage: withFinishedUnselectedImage:]
+        cell.iconImage = item.finishedUnselectedImage;
+    }
+    
+    //see if there is a selected image to show
+    if(item.finishedSelectedImage != nil)
+    {
+        cell.iconSelectedImage = item.finishedSelectedImage;
+    }
+    
     
     return cell;
 }

--- a/src/FSVerticalTabBarButton.h
+++ b/src/FSVerticalTabBarButton.h
@@ -14,6 +14,7 @@
 
 @property (nonatomic, readwrite, assign) UIColor *selectedImageTintColor;
 @property (nonatomic, readwrite, strong) UIImage *iconImage;
+@property (nonatomic, readwrite, strong) UIImage *iconSelectedImage;
 
 
 @end

--- a/src/FSVerticalTabBarButton.m
+++ b/src/FSVerticalTabBarButton.m
@@ -14,6 +14,7 @@
 
 @synthesize selectedImageTintColor = _selectedImageTintColor;
 @synthesize iconImage = _iconImage;
+@synthesize iconSelectedImage = _iconSelectedImage;
 
 
 - (UIColor *)selectedImageTintColor
@@ -53,8 +54,15 @@
                                   imageSize.width,
                                   imageSize.height);
     
-    // draw either a selection gradient/glow or a regular image
-    if (self.isSelected)
+    // draw a selection gradient/glow, the selected image, or a regular image
+    if (self.isSelected && self.iconSelectedImage != nil)
+    {
+        //item is selected and we have a selected image to show
+        CGContextDrawImage(context,
+                           imageRect,
+                           self.iconSelectedImage.CGImage);
+        
+    } else if (self.isSelected)
     {
         // setup shadow
         CGSize shadowOffset = CGSizeMake(0.0f, 1.0f);


### PR DESCRIPTION
Bug fix that allows the vertical tab bar to have the option to show selected tab images instead of just the highlighted gradient. This is a standard feature on the UITabBarController and should be supported by FSVerticalTabBarController.

To test, instead of setting the tabBar image directly use the following code:

```
 [tabBarItem setFinishedSelectedImage:[UIImage imageNamed:@"selected_image.png"] withFinishedUnselectedImage:[UIImage imageNamed:@"image.png"]];
```
