### PR TITLE
FIX: sometime other tabs could not be selected once loaded.

### DIFF
--- a/src/FSVerticalTabBarController.m
+++ b/src/FSVerticalTabBarController.m
@@ -199,7 +199,7 @@
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    BOOL result;
+    BOOL result=YES;
     
     if ([self.delegate respondsToSelector:@selector(tabBarController:shouldSelectViewController:)]) {
         UIViewController *newController = [self.viewControllers objectAtIndex:indexPath.row];


### PR DESCRIPTION
A boolean value is used without initialisation and could be true or false without predictability. 
